### PR TITLE
Refresco de listado al agregar item

### DIFF
--- a/todo-react/src/ToDo/ToDoAddItem/ToDoAddItem.js
+++ b/todo-react/src/ToDo/ToDoAddItem/ToDoAddItem.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import ToDoService from '../../services/ToDoService';
 import {connect} from "react-redux";
-
-export default class ToDoAddItem extends React.Component {
+ class ToDoAddItem extends React.Component {
 
     constructor(props) {
         super(props);
@@ -20,16 +19,20 @@ export default class ToDoAddItem extends React.Component {
     }
 
     addItem() {
+        var parentThis = this;
         this.toDoService.postTarea( {
             name: this.state.inputTarea,
             isComplete: false
         })
             .then(function (response) {
                 console.log(response);
+                parentThis.props.onAdd(response);
             })
             .catch(function (error) {
                 console.log(error);
-            });;
+            });
+
+        /* Otra opcion es con Async Await */            
     }
 
     /**
@@ -81,3 +84,12 @@ export default class ToDoAddItem extends React.Component {
         )
     }
 }
+
+// this.props.onAdd es la comunicacion con el reducer (para agregarlo al listado)
+var mapToActions = function(dispatch) {
+    return {
+        onAdd: (nuevoItem) => dispatch({type: 'ADD_ITEM', data: nuevoItem})
+    }
+}
+
+export default connect(null, mapToActions)(ToDoAddItem);

--- a/todo-react/src/store/todoReducer.js
+++ b/todo-react/src/store/todoReducer.js
@@ -10,8 +10,13 @@ export default function(estadoActual = estadoInicial, action)
 {
     switch (action.type) {
         case 'ADD_ITEM':
-
-            break;
+            var nuevoItem = action.data;
+            return {
+                taskList: [
+                    ...estadoActual.taskList,
+                    nuevoItem
+                ]
+            }
         case 'REMOVE_ITEM':
 
             break;
@@ -19,8 +24,6 @@ export default function(estadoActual = estadoInicial, action)
             return {
                 taskList: action.data
             }
-
-            break;
         case 'UPDATE_ITEM':
 
             break;


### PR DESCRIPTION
ToDoAddItem

- La exportación no es de la clase directo, sino del Connect 
- Hay que realizar un map del evento que se comunica con el store (reducer)
- Dentro de la promise, el this no corresponde al objeto, sino al entorno de la promise, por eso creo una variable que apunte al this (instancia de ToDoAddItem) y luego en la promise uso esa variable

toDoReducer

- Incorporo la funcionalidad de agregar al listado de ToDos